### PR TITLE
Changed from createObjectURL() to srcObject

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 <script src="js/vendor/modernizr.min.js"></script>
 <script src="js/vendor/bootstrap.min.js"></script>
 <script src="js/vendor/jquery.Jcrop.js"></script>
-<script src="js/vendor/ocrad.min.js"></script>
+<script src='https://cdn.jsdelivr.net/gh/naptha/tesseract.js@v1.0.14/dist/tesseract.min.js'></script>
 <script src="js/vendor/glfx.min.js"></script>
 
 <script src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -192,13 +192,16 @@
             cropData.w * scale,
             cropData.h * scale);
 
-        //use ocrad.js to extract text from the canvas
-        var resultText = OCRAD(ctx);
-        resultText = resultText.trim();
+        //Replaced OCRAD with Tesseract
+        Tesseract.recognize(ctx).then(function(result1){
+            var resultText = result1.text;
+
+            resultText = resultText.trim();
 
         //show the result
         $('blockquote p').html('&bdquo;' + resultText + '&ldquo;');
         $('blockquote footer').text('(' + resultText.length + ' characters)')
+        });
     }
 
     /*********************************

--- a/js/main.js
+++ b/js/main.js
@@ -82,9 +82,7 @@
 
         getUserMedia(videoSettings, function (stream) {
             //Setup the video stream
-            video.src = window.URL.createObjectURL(stream);
-
-            window.stream = stream;
+            video.srcObject=stream;
 
             video.addEventListener("loadedmetadata", function (e) {
                 //get video width and height as it might be different than we requested


### PR DESCRIPTION
Camera not working anymore because createObjectURL function is deprecated (in Chrome at least). Updated code to simply set srcObject to the MediaStream directly.